### PR TITLE
v0.1.5

### DIFF
--- a/io.github.josephmawa.Bella.json
+++ b/io.github.josephmawa.Bella.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.josephmawa.Bella",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "io.github.josephmawa.Bella",
   "finish-args": [
@@ -34,8 +34,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/flatpak/libportal/releases/download/0.8.1/libportal-0.8.1.tar.xz",
-          "sha256": "281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac"
+          "url": "https://github.com/flatpak/libportal/releases/download/0.9.1/libportal-0.9.1.tar.xz",
+          "sha256": "de801ee349ed3c255a9af3c01b1a401fab5b3fc1c35eb2fd7dfb35d4b8194d7f"
         }
       ]
     },
@@ -47,8 +47,8 @@
         {
           "type": "git",
           "url": "https://github.com/josephmawa/Bella",
-          "tag": "v0.1.4",
-          "commit": "42deea89ba6fff62a7295f4b257af2e5f4b6d823"
+          "tag": "v0.1.5",
+          "commit": "870847b90894025c274ca87a21ece4b48b42f288"
         }
       ]
     }


### PR DESCRIPTION
Release v0.1.5 with the following changes:

- Upgrade to GNOME runtime version 48
- Upgrade to the latest version of Libportal
- Display Hex color in lowercase
